### PR TITLE
Allow macros to work regardless of what's in scope

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -136,7 +136,7 @@ impl std::fmt::Debug for Expression {
 #[macro_export]
 macro_rules! expr {
     ($e : expr) => {{
-        let synexpr: syn::Expr = syn::parse_quote!($e);
+        let synexpr: $crate::syn::Expr = $crate::syn::parse_quote!($e);
         $crate::Expression::from(synexpr)
     }};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,10 @@ pub mod transformation;
 pub mod variablelist;
 pub mod visitor;
 
+// Re-export for use in macros.
+#[doc(hidden)]
+pub use syn;
+
 #[cfg(test)]
 mod tests;
 

--- a/src/name.rs
+++ b/src/name.rs
@@ -40,7 +40,7 @@ impl std::fmt::Debug for Name {
 #[macro_export]
 macro_rules! name {
     ($e : expr) => {{
-        let path: syn::Path = syn::parse_quote!($e);
+        let path: $crate::syn::Path = $crate::syn::parse_quote!($e);
         $crate::Name::from(path)
     }};
 }

--- a/src/variablelist.rs
+++ b/src/variablelist.rs
@@ -36,7 +36,7 @@ impl VariableList {
 #[macro_export]
 macro_rules! vars {
     ($($i : ident = $e : expr),*) => {
-        $crate::VariableList::from(vec![$(($crate::name!($i), $crate::expr!($e))),*])
+        $crate::VariableList::from(::std::vec![$(($crate::name!($i), $crate::expr!($e))),*])
     }
 }
 


### PR DESCRIPTION
Previous code assumes `syn` is in scope (and that `vec` is in the prelude). There are a number of reasons this might not be the case at the site the macro will be invoked, so it's better to go through a reexport in macros.