### PR TITLE
Add CI via github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+env:
+  RUST_BACKTRACE: 1
+
+jobs:
+  test:
+    name: Test Rust ${{ matrix.rust }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { rust: stable,           os: ubuntu-latest }
+          - { rust: stable,           os: macos-latest }
+          - { rust: stable,           os: windows-latest }
+          - { rust: stable-i686-msvc, os: windows-latest }
+          - { rust: beta,             os: ubuntu-latest }
+          - { rust: nightly,          os: ubuntu-latest }
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: ${{ matrix.rust }}
+          components: rustfmt
+      - run: cargo test --verbose --workspace
+      - run: cargo run --bin libmgen
+      - name: Dump/Format the generated libm for debugging purposes
+        run: |
+          # Dump a formatted version to stdout, so that it can be inspected.
+          rustfmt --emit=stdout tests/libm.rs
+          # Also actually format it, to improve error output.
+          rustfmt tests/libm.rs
+      # Ensure the generated libm still passes tests
+      - run: cargo test --verbose --workspace
+
+  check-warnings:
+    name: cargo check
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -Dwarnings
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hecrj/setup-rust-action@v1
+        with:
+          components: rustfmt
+      - run: cargo check --workspace --all-targets --verbose
+      - name: Regenerate libm
+        run: |
+          cargo run libmgen
+          rustfmt --emit=stdout tests/libm.rs
+          rustfmt tests/libm.rs
+      # See if the new libm has warnings
+      - run: cargo check --test libm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - run: cargo check --workspace --all-targets --verbose
       - name: Regenerate libm
         run: |
-          cargo run libmgen
+          cargo run --bin libmgen
           rustfmt --emit=stdout tests/libm.rs
           rustfmt tests/libm.rs
       # See if the new libm has warnings

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # doctor-syn
+[![Build Status](https://github.com/extendr/doctor-syn/workflows/CI/badge.svg)](https://github.com/extendr/doctor-syn/actions)
 
 ## rationale
 


### PR DESCRIPTION
I noticed there's no CI in this repo when writing #1. I've done this a bajillion times (and even wrote a blog post on how to do it https://shift.click/blog/github-actions-rust), so I figured I'd take a stab.

---

This setup does the following things:
- Tests on stable rust for mac/linux/win32/win64.
- Tests on beta and nightly, to give you heads up about any breakage coming down the pipe.
- Ensures that `cargo check` passes without emitting any warnings.

(Last two are only done on linux since there isn't platform-specific code, and linux CI tends to run the fastest on GHA)

Tests/checks are performed in two passes:
- first on what's in the tree.
- second after running libmgen, to ensure there's no case where problem only exists after producing the new output.

After each regeneration of tests/libm.rs, it dumps (a formatted version of) the result to stdout (so that you can inspect it in the overview) and then reruns the test/check. This is a bit cludgey<sup>1</sup>, but works fine and catches most problems.

It's set up to run for:
- Every PR (although as of recently you have to manually approve CI runs for first-time contributors).
- Every commit landing directly on `main`.

Note that CI configuration isn't really something I can test locally, and this ended up being complex enough that I might have made a mistake somewhere — so apologies in advance if this takes a couple commits to get passing.

---

1: I think ideally, we'd also ensure that the thing checked into tests/libm.rs (after formatting) matches the output of libmgen.

This would be easy for me to add, but hits issues with floating point determinism — on my machine (macOS) the output doesn't quite match (the diff is https://gist.github.com/thomcc/9046709cf1bed55da54d30a7e2b68176).

So, I think doing that might be blocked on doctor_syn being more deterministic (or perhaps computing stuff internally with arbitrary precision — assuming that's an eventual goal).

Until then, it's probably enough for it to be just worth keeping an eye on for PRs, e.g. the reviewer should check that if the PR is expected to modify the libmgen output, that it also includes an update to tests/libm.rs.

That said, we still test that code, so its not the worst thing in the world if this gets forgotten by accident.